### PR TITLE
Default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [TO BE DEPRECATED]
 - "useLegacyDefaultValue" option has to be removed.
-- Accept options only as second argument. Id should be defined only using the "uuid" option.
+- Options should be accepted only as second argument. "uuid" should be defined only using the "uuid" option, not as second argument.
 
 ## [2.0.0] - 2019-10-15
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - "useLegacyDefaultValue" option has to be removed.
 - Accept options only as second argument. Id should be defined only using the "uuid" option.
 
-## [1.2.0] - 2019-10-15
+## [2.0.0] - 2019-10-15
 ### BREAKING CHANGES
 - Queried instances will have default value corresponding to the value of query "key" in the default value object (until new option "useLegacyDefaultValue" is received, in which case the behavior of "default value" will be the same than in previous versions)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [TO BE DEPRECATED]
+- "useLegacyDefaultValue" option has to be removed.
+- Accept options only as second argument. Id should be defined only using the "uuid" option.
+
 ## [1.2.0] - 2019-10-15
+### BREAKING CHANGES
+- Queried instances will have default value corresponding to the value of query "key" in the default value object (until new option "useLegacyDefaultValue" is received, in which case the behavior of "default value" will be the same than in previous versions)
+
+### Added
+- Add "useLegacyDefaultValue" option.
+- Add "uuid" and "tags" options.
+- Accept options object as second argument. (And still accepts "id" as second argument, and options as third argument in order to maintain retro-compatibility)
+
 ### Changed
-- Upgrade mercury version and define it as peer dependency
-- Upgrade devDependencies
+- Upgrade mercury version and define it as peer dependency.
+- Upgrade devDependencies.
 
 ## [1.1.0] - 2019-06-28
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ npm i @xbyorange/mercury-memory --save
 
 ## Api
 
-`new Memory(object[, id])`
+`new Memory(defaultValue[, options || uuid][, options])`
 * Arguments
-  * object - _`<Object>`_. Object to be stored. Default value is assigned too at the same time.
-  * id - _`<String>`_ Id of the Mercury Object. Optional, only useful for debugging purposes.
+	* defaultValue - _`<Object>`_. Object to be stored. Default value is assigned too at the same time.
+	* uuid - _`<String>`_. Unique id to assign to returned Mercury instance. Useful when using [mercury `sources` handler][mercury-sources-docs-url]. __To be deprecated in next releases. Options object should be passed as second argument instead of uuid.__
+	* options - `<Object>` containing properties:
+		* useLegacyDefaultValue - _`<Boolean>`_ If `true`, the default value of queried sources will be the full `defaultValue` object. If not provided, the default value of queried sources will be the value of the "key" in the query.
+		* uuid - _`<String>`_ Unique id to assign to returned Mercury instance. Useful when using [mercury `sources` handler][mercury-sources-docs-url].
+		* tags - _`<String> or <Array of Strings>`_ Tags to assign to the instance. Useful when using [mercury `sources` handler][mercury-sources-docs-url]. A "prismic" tag will be always added to provided tags by default.
 
 ## Methods
 
@@ -36,10 +40,8 @@ npm i @xbyorange/mercury-memory --save
 
 ### cache
 
-The `clean` events will be dispatched when the `update`, `delete` or `create` methods are executed for an specific query as in other mercury origins:
+All cache will be cleaned when the `update`, `delete` or `create` methods are executed for any specific query.
 
-* If `update` or `delete` methods are executed over the origin without query, cache of all queried resources will be cleaned too.
-* All `cache` will be cleaned if the `create` method is executed.
 
 ## Examples
 
@@ -111,6 +113,7 @@ Contributors are welcome.
 Please read the [contributing guidelines](.github/CONTRIBUTING.md) and [code of conduct](.github/CODE_OF_CONDUCT.md).
 
 [mercury-url]: https://github.com/xbyorange/mercury
+[mercury-sources-docs-url]: https://github.com/XbyOrange/mercury/blob/master/docs/sources/api.md
 
 [coveralls-image]: https://coveralls.io/repos/github/XbyOrange/mercury-memory/badge.svg
 [coveralls-url]: https://coveralls.io/github/XbyOrange/mercury-memory

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbyorange/mercury-memory",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbyorange/mercury-memory",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Mercury memory origin",
   "keywords": [
     "reactive",

--- a/src/Memory.js
+++ b/src/Memory.js
@@ -1,9 +1,20 @@
 import { Origin } from "@xbyorange/mercury";
 import { cloneDeep } from "lodash";
 
+const TAG = "memory";
+
 export class Memory extends Origin {
-  constructor(value, id) {
-    super(id || "memory", value);
+  constructor(value, id, options = {}) {
+    const tags = Array.isArray(options.tags) ? options.tags : [options.tags];
+    tags.push(TAG);
+    const baseOptions = {
+      ...options,
+      tags
+    };
+    if (!options.uuid && id) {
+      baseOptions.uuid = id;
+    }
+    super(id || "memory", value, baseOptions);
     this._memory = cloneDeep(value || {});
     this.update(this._memory);
   }

--- a/src/Memory.js
+++ b/src/Memory.js
@@ -14,9 +14,20 @@ export class Memory extends Origin {
     if (!options.uuid && id) {
       baseOptions.uuid = id;
     }
-    super(id || "memory", value, baseOptions);
+    const getDefaultValue = function(query) {
+      const valueToReturn = value || {};
+      if (query && !options.useLegacyDefaultValue) {
+        return valueToReturn[query];
+      }
+      return valueToReturn;
+    };
+    super(id || "memory", getDefaultValue, baseOptions);
     this._memory = cloneDeep(value || {});
     this.update(this._memory);
+  }
+
+  _config(configuration) {
+    this._useLegacyDefaultValue = configuration.useLegacyDefaultValue;
   }
 
   _read(key) {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "globals": {
+    "afterEach": true,
     "beforeAll": true,
     "beforeEach": true,
     "describe": true,

--- a/test/memory.spec.js
+++ b/test/memory.spec.js
@@ -1,6 +1,11 @@
+const { sources } = require("@xbyorange/mercury");
 const { Memory } = require("../src/index");
 
 describe("Memory origin", () => {
+  afterEach(() => {
+    sources.clear();
+  });
+
   describe("Available methods", () => {
     it("should have all CRUD methods", () => {
       const userData = new Memory();
@@ -64,26 +69,51 @@ describe("Memory origin", () => {
       foo: "foo-value"
     };
 
-    beforeEach(async () => {
+    beforeEach(() => {
       userData = new Memory(fooData);
     });
 
-    it("should return default value while resource is being loaded", () => {
-      expect.assertions(2);
-      const promise = userData.read();
-      expect(userData.read.value).toEqual(fooData);
-      return promise.then(() => {
+    describe("whithout query", () => {
+      it("should return default value while resource is being loaded", () => {
+        expect.assertions(2);
+        const promise = userData.read();
         expect(userData.read.value).toEqual(fooData);
+        return promise.then(() => {
+          expect(userData.read.value).toEqual(fooData);
+        });
+      });
+
+      it("should be accesible through getter", async () => {
+        expect.assertions(1);
+        await userData.read();
+        expect(userData.read.getters.value()).toEqual(fooData);
       });
     });
 
-    it("should be accesible through getter", async () => {
-      expect.assertions(1);
-      await userData.read();
-      expect(userData.read.getters.value()).toEqual(fooData);
-    });
-
     describe("when queried", () => {
+      it("should return default value correspondent to query while resource is being loaded", () => {
+        expect.assertions(2);
+        let queriedData = userData.query("foo");
+        const promise = queriedData.read();
+        expect(queriedData.read.value).toEqual(fooData.foo);
+        return promise.then(() => {
+          expect(queriedData.read.value).toEqual(fooData.foo);
+        });
+      });
+
+      it("should return root default value if useLegacyDefaultValue option is set", () => {
+        expect.assertions(2);
+        userData = new Memory(fooData, "foo-id", {
+          useLegacyDefaultValue: true
+        });
+        let queriedData = userData.query("foo");
+        const promise = queriedData.read();
+        expect(queriedData.read.value).toEqual(fooData);
+        return promise.then(() => {
+          expect(queriedData.read.value).toEqual(fooData.foo);
+        });
+      });
+
       it("should return the property corresponding to applied query", async () => {
         let queriedData = userData.query("foo");
         const result = await queriedData.read();
@@ -197,6 +227,109 @@ describe("Memory origin", () => {
       expect(value).toEqual({
         foo: "foo-value",
         foo2: "foo-new"
+      });
+    });
+  });
+
+  describe("Instance id", () => {
+    it("should be assigned based on second parameter", () => {
+      const FOO_ID = "foo-id";
+      const fooData = new Memory(null, FOO_ID);
+      expect(sources.getById(FOO_ID).elements[0]).toEqual(fooData);
+    });
+
+    it("should be assigned based on uuid option if provided", () => {
+      const FOO_ID = "foo-id";
+      const fooData = new Memory(null, "foo-fake-id", {
+        uuid: FOO_ID
+      });
+      expect(sources.getById(FOO_ID).elements[0]).toEqual(fooData);
+    });
+
+    it("should be assigned based on uuid option if provided as second argument", () => {
+      const FOO_ID = "foo-id";
+      const fooData = new Memory(null, {
+        uuid: FOO_ID
+      });
+      expect(sources.getById(FOO_ID).elements[0]).toEqual(fooData);
+    });
+  });
+
+  describe("Instance tags", () => {
+    describe("when no options are defined", () => {
+      it("should contain the memory tag", () => {
+        const fooData = new Memory(null);
+        expect(sources.getByTag("memory").elements[0]).toEqual(fooData);
+      });
+    });
+
+    describe("when passing options as second argument", () => {
+      it("should contain the memory tag even when a custom tag is received", () => {
+        const fooData = new Memory(null, {
+          tags: "foo-tag"
+        });
+        expect(sources.getByTag("memory").elements[0]).toEqual(fooData);
+      });
+
+      it("should contain the memory tag even when an array of custom tags is received", () => {
+        const fooData = new Memory(null, {
+          tags: ["foo-tag", "foo-tag-2"]
+        });
+        expect(sources.getByTag("memory").elements[0]).toEqual(fooData);
+      });
+
+      it("should contain defined custom tag if received", () => {
+        const FOO_TAG = "foo-tag";
+        const fooData = new Memory(null, {
+          tags: FOO_TAG
+        });
+        expect(sources.getByTag(FOO_TAG).elements[0]).toEqual(fooData);
+      });
+
+      it("should contain defined custom tags if received", () => {
+        expect.assertions(2);
+        const FOO_TAG = "foo-tag";
+        const FOO_TAG_2 = "foo-tag-2";
+        const fooData = new Memory(null, {
+          tags: [FOO_TAG, FOO_TAG_2]
+        });
+        expect(sources.getByTag(FOO_TAG).elements[0]).toEqual(fooData);
+        expect(sources.getByTag(FOO_TAG_2).elements[0]).toEqual(fooData);
+      });
+    });
+
+    describe("when passing options as third argument", () => {
+      it("should contain the memory tag even when a custom tag is received", () => {
+        const fooData = new Memory(null, "foo-fake-id", {
+          tags: "foo-tag"
+        });
+        expect(sources.getByTag("memory").elements[0]).toEqual(fooData);
+      });
+
+      it("should contain the memory tag even when an array of custom tags is received", () => {
+        const fooData = new Memory(null, "foo-fake-id", {
+          tags: ["foo-tag", "foo-tag-2"]
+        });
+        expect(sources.getByTag("memory").elements[0]).toEqual(fooData);
+      });
+
+      it("should contain defined custom tag if received", () => {
+        const FOO_TAG = "foo-tag";
+        const fooData = new Memory(null, "foo-fake-id", {
+          tags: FOO_TAG
+        });
+        expect(sources.getByTag(FOO_TAG).elements[0]).toEqual(fooData);
+      });
+
+      it("should contain defined custom tags if received", () => {
+        expect.assertions(2);
+        const FOO_TAG = "foo-tag";
+        const FOO_TAG_2 = "foo-tag-2";
+        const fooData = new Memory(null, "foo-fake-id", {
+          tags: [FOO_TAG, FOO_TAG_2]
+        });
+        expect(sources.getByTag(FOO_TAG).elements[0]).toEqual(fooData);
+        expect(sources.getByTag(FOO_TAG_2).elements[0]).toEqual(fooData);
       });
     });
   });


### PR DESCRIPTION
## [TO BE DEPRECATED]
- "useLegacyDefaultValue" option has to be removed.
- Accept options only as second argument. Id should be defined only using the "uuid" option.

### BREAKING CHANGES
- Queried instances will have default value corresponding to the value of query "key" in the default value object (until new option "useLegacyDefaultValue" is received, in which case the behavior of "default value" will be the same than in previous versions)

### Added
- Add "useLegacyDefaultValue" option.
- Add "uuid" and "tags" options.
- Accept options object as second argument. (And still accepts "id" as second argument, and options as third argument in order to maintain retro-compatibility)

### Changed
- Upgrade mercury version and define it as peer dependency.
- Upgrade devDependencies.