### PR TITLE
Clean event over root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Accept options object as second argument. (And still accepts "id" as second argument, and options as third argument in order to maintain retro-compatibility)
 
 ### Changed
+- Emit "clean" event over root instance when an "update" is executed on any queried instance. (Full object is modified too).
 - Upgrade mercury version and define it as peer dependency.
 - Upgrade devDependencies.
 

--- a/src/Memory.js
+++ b/src/Memory.js
@@ -78,7 +78,7 @@ export class Memory extends Origin {
     } else {
       this._memory = data;
     }
-    this._clean(query);
+    this._clean();
     return Promise.resolve();
   }
 

--- a/test/memory.spec.js
+++ b/test/memory.spec.js
@@ -132,24 +132,26 @@ describe("Memory origin", () => {
       userData = new Memory(fooData);
     });
 
-    it("should clean the cache when finish successfully", async () => {
-      expect.assertions(3);
-      let promise = userData.read();
-      expect(userData.read.loading).toEqual(true);
-      await promise;
-      await userData.update("");
-      promise = userData.read();
-      expect(userData.read.loading).toEqual(true);
-      return promise.then(() => {
-        expect(userData.read.loading).toEqual(false);
+    describe("without query", () => {
+      it("should clean the cache when finish successfully", async () => {
+        expect.assertions(3);
+        let promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        await promise;
+        await userData.update("");
+        promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        return promise.then(() => {
+          expect(userData.read.loading).toEqual(false);
+        });
       });
-    });
 
-    it("should set the new value", async () => {
-      const newValue = { foo2: "foo-new-value" };
-      await userData.update(newValue);
-      const value = await userData.read();
-      expect(value).toEqual(newValue);
+      it("should set the new value", async () => {
+        const newValue = { foo2: "foo-new-value" };
+        await userData.update(newValue);
+        const value = await userData.read();
+        expect(value).toEqual(newValue);
+      });
     });
 
     describe("when queried", () => {
@@ -159,6 +161,19 @@ describe("Memory origin", () => {
         const value = await userData.read();
         expect(value).toEqual({
           foo: "foo-updated-value"
+        });
+      });
+
+      it("should clean the cache of root when finish successfully", async () => {
+        expect.assertions(3);
+        let promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        await promise;
+        await userData.query("foo").update("");
+        promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        return promise.then(() => {
+          expect(userData.read.loading).toEqual(false);
         });
       });
     });


### PR DESCRIPTION
### Changed
- Emit "clean" event over root instance when an "update" is executed on any queried instance. (Full object is modified too).